### PR TITLE
fix repo name

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -54,7 +54,7 @@ module.exports = {
         ]
       }
     ],
-    repo: 'tobyz/json-api-server',
+    repo: 'tobyzerner/json-api-server',
     editLinks: true,
     docsDir: 'docs'
   }


### PR DESCRIPTION
fix the nav link to the github repository on the documentation site  (https://tobyzerner.github.io/json-api-server/)