### PR TITLE
Get create and update data from specifically from request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0-beta.3] - 2021-09-03
+### Fixed
+- Fix dependency on `http-accept` now that a version has been tagged
+- Change `EloquentAdapter` to load relationships using `load` instead of `loadMissing`, as they may need API-specific scopes applied
+
 ## [0.2.0-beta.2] - 2021-09-01
 ### Added
 - Content-Type validation and Accept negotation

--- a/src/Context.php
+++ b/src/Context.php
@@ -86,4 +86,12 @@ class Context
     {
         return $this->request->getQueryParams()['filter'][$name] ?? null;
     }
+
+    /**
+     * Get parsed JsonApi payload
+     */
+    public function getBody(): ?array
+    {
+        return json_decode($this->request->getBody()->getContents(), true);
+    }
 }

--- a/src/Endpoint/Create.php
+++ b/src/Endpoint/Create.php
@@ -42,7 +42,7 @@ class Create
         }
 
         $model = $this->newModel($resourceType, $context);
-        $data = $this->parseData($resourceType, $context->getBody(), $model);
+        $data = $this->parseData($resourceType, $context->getBody());
 
         $this->validateFields($resourceType, $data, $model, $context);
         $this->fillDefaultValues($resourceType, $data, $context);

--- a/src/Endpoint/Create.php
+++ b/src/Endpoint/Create.php
@@ -42,11 +42,7 @@ class Create
         }
 
         $model = $this->newModel($resourceType, $context);
-        $data = $this->parseData(
-            $resourceType,
-            json_decode($context->getRequest()->getBody()->getContents(), true),
-            $model
-        );
+        $data = $this->parseData($resourceType, $context->getBody(), $model);
 
         $this->validateFields($resourceType, $data, $model, $context);
         $this->fillDefaultValues($resourceType, $data, $context);

--- a/src/Endpoint/Create.php
+++ b/src/Endpoint/Create.php
@@ -42,7 +42,11 @@ class Create
         }
 
         $model = $this->newModel($resourceType, $context);
-        $data = $this->parseData($resourceType, $context->getRequest()->getParsedBody());
+        $data = $this->parseData(
+            $resourceType,
+            json_decode($context->getRequest()->getBody()->getContents(), true),
+            $model
+        );
 
         $this->validateFields($resourceType, $data, $model, $context);
         $this->fillDefaultValues($resourceType, $data, $context);

--- a/src/Endpoint/Update.php
+++ b/src/Endpoint/Update.php
@@ -40,7 +40,11 @@ class Update
             ));
         }
 
-        $data = $this->parseData($resourceType, $context->getRequest()->getParsedBody(), $model);
+        $data = $this->parseData(
+            $resourceType,
+            json_decode($context->getRequest()->getBody()->getContents(), true),
+            $model
+        );
 
         $this->validateFields($resourceType, $data, $model, $context);
         $this->loadRelatedResources($resourceType, $data, $context);

--- a/src/Endpoint/Update.php
+++ b/src/Endpoint/Update.php
@@ -40,11 +40,7 @@ class Update
             ));
         }
 
-        $data = $this->parseData(
-            $resourceType,
-            json_decode($context->getRequest()->getBody()->getContents(), true),
-            $model
-        );
+        $data = $this->parseData($resourceType, $context->getBody(), $model);
 
         $this->validateFields($resourceType, $data, $model, $context);
         $this->loadRelatedResources($resourceType, $data, $context);


### PR DESCRIPTION
I was using Symfony PSR bridge found that `getParsedBody()` can parse form data, URL encoded data and request body, there is no guarantee it gives data specifically from the request body.
This PR enforces that we fetch data from the body specifically.