### PR TITLE
Upgrade http-accept library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
     "name": "tobyz/json-api-server",
     "description": "A fully automated JSON:API server implementation in PHP.",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.3",
         "ext-json": "*",
+        "asispts/http-accept": "^1.0",
         "doctrine/inflector": "^1.4 || ^2.0",
         "json-api-php/json-api": "^2.2",
         "nyholm/psr7": "^1.3",
         "psr/http-message": "^1.0",
-        "psr/http-server-handler": "^1.0",
-        "hnet/http-accept": "^0.1"
+        "psr/http-server-handler": "^1.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Since the new version of `http-accept` requires at least PHP `7.2`, this pull request should be merged after #64.