### PR TITLE
Add enum() method to Str class

### DIFF
--- a/src/Schema/Field/Str.php
+++ b/src/Schema/Field/Str.php
@@ -8,6 +8,7 @@ class Str extends Attribute
     public ?int $maxLength = null;
     public ?string $pattern = null;
     public ?string $format = null;
+    public ?array $enum = null;
 
     public function __construct(string $name)
     {
@@ -19,6 +20,11 @@ class Str extends Attribute
             if (!is_string($value)) {
                 $fail('must be a string');
                 return;
+            }
+
+            if ($this->enum !== null && !in_array($value, $this->enum, true)) {
+                $enum = array_map(fn ($value) => '"' . $value . '"', $this->enum);
+                $fail(sprintf('must be one of %s', implode(', ', $enum)));
             }
 
             if (strlen($value) < $this->minLength) {
@@ -62,6 +68,13 @@ class Str extends Attribute
     public function format(?string $format): static
     {
         $this->format = $format;
+
+        return $this;
+    }
+
+    public function enum(?array $enum): static
+    {
+        $this->enum = $enum;
 
         return $this;
     }

--- a/src/Schema/Field/Str.php
+++ b/src/Schema/Field/Str.php
@@ -87,6 +87,7 @@ class Str extends Attribute
             'maxLength' => $this->maxLength,
             'pattern' => $this->pattern,
             'format' => $this->format,
+            'enum' => $this->enum,
         ];
     }
 }

--- a/tests/feature/StrTest.php
+++ b/tests/feature/StrTest.php
@@ -57,4 +57,46 @@ class StrTest extends AbstractTestCase
             ]),
         );
     }
+
+    public function test_invalid_enum()
+    {
+        $this->api->resource(
+            new MockResource(
+                'users',
+                endpoints: [Create::make()],
+                fields: [Str::make('type')->writable()->enum(['A', 'B'])],
+            ),
+        );
+
+        $this->expectException(UnprocessableEntityException::class);
+
+        $this->api->handle(
+            $this->buildRequest('POST', '/users')->withParsedBody([
+                'data' => ['type' => 'users', 'attributes' => ['type' => 'C']],
+            ]),
+        );
+    }
+
+    public function test_valid_enum()
+    {
+        $this->api->resource(
+            new MockResource(
+                'users',
+                endpoints: [Create::make()],
+                fields: [Str::make('type')->writable()->enum(['A', 'B'])],
+            ),
+        );
+
+        $response = $this->api->handle(
+            $this->buildRequest('POST', '/users')->withParsedBody([
+                'data' => ['type' => 'users', 'attributes' => ['type' => 'A']],
+            ]),
+        );
+
+        $this->assertJsonApiDocumentSubset(
+            ['data' => ['attributes' => ['type' => 'A']]],
+            $response->getBody(),
+            true,
+        );
+    }
 }


### PR DESCRIPTION
Hi,

I propose to add a new `enum()` method on the `Str` class. This would make validation of enum properties a lot easier, so we don't need to manually write something like this every time we have an enum property:

```
Str::make('example')
    ->validate(function (mixed $value, callable $fail) {
        if (!in_array($value, [... allowed values ...])) {
            $fail('must be one of: ' . implode(', ', [... allowed values ...]));
        }
    });
```

It would also tie in nicely with the `enum` keyword in JSON schema which is used in OpenAPI specs, so it would also be possible to document the possible enum values in the auto-generated OpenAPI documentation that you are working on in #62 

See: https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.1

(Technically JSON schema allows this attribute on any type, but it seemed most useful to me on string fields for now. It could also be added to other fields later of course.)