### PR TITLE
Literal defaults

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -200,24 +200,18 @@ Str::make('email')->writableOnCreate();
 ### Default Values
 
 If you would like to provide a default value to be used when creating a new
-resource if there is no value provided in the request, you can pass a closure to
-the `default` method.
+resource if there is no value provided in the request, you can pass a closure or
+a literal value to the `default` method.
 
-The closure will receive the current request context as an argument when called.
-
-```php
-use Tobyz\JsonApiServer\Field\DateTime;
-
-DateTime::make('joinedAt')->default(fn(Context $context) => new \DateTime());
-```
-
-Alternatively, you can pass a literal default value to the `defaultLiteral`
-method:
+A closure will receive the current request context as an argument when called.
 
 ```php
-use Tobyz\JsonApiServer\Field\DateTime;
+use Tobyz\JsonApiServer\Field;
 
-Str::make('color')->defaultLiteral('blue');
+Field\Str::make('name')->default('Anonymous');
+Field\DateTime::make('joinedAt')->default(
+    fn(Context $context) => new \DateTime(),
+);
 ```
 
 ### Required

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -201,7 +201,7 @@ Str::make('email')->writableOnCreate();
 
 If you would like to provide a default value to be used when creating a new
 resource if there is no value provided in the request, you can pass a closure to
-the `default` method. 
+the `default` method.
 
 The closure will receive the current request context as an argument when called.
 
@@ -211,7 +211,8 @@ use Tobyz\JsonApiServer\Field\DateTime;
 DateTime::make('joinedAt')->default(fn(Context $context) => new \DateTime());
 ```
 
-Alternatively, you can pass a literal default value to the `defaultLiteral` method:
+Alternatively, you can pass a literal default value to the `defaultLiteral`
+method:
 
 ```php
 use Tobyz\JsonApiServer\Field\DateTime;

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -201,12 +201,22 @@ Str::make('email')->writableOnCreate();
 
 If you would like to provide a default value to be used when creating a new
 resource if there is no value provided in the request, you can pass a closure to
-the `default` method:
+the `default` method. 
+
+The closure will receive the current request context as an argument when called.
 
 ```php
 use Tobyz\JsonApiServer\Field\DateTime;
 
-DateTime::make('joinedAt')->default(fn() => new \DateTime());
+DateTime::make('joinedAt')->default(fn(Context $context) => new \DateTime());
+```
+
+Alternatively, you can pass a literal default value to the `defaultLiteral` method:
+
+```php
+use Tobyz\JsonApiServer\Field\DateTime;
+
+Str::make('color')->defaultLiteral('blue');
 ```
 
 ### Required

--- a/src/Schema/Concerns/SetsValue.php
+++ b/src/Schema/Concerns/SetsValue.php
@@ -49,11 +49,21 @@ trait SetsValue
     }
 
     /**
-     * Set a default value for this field.
+     * Set a default value for this field via a callback.
      */
     public function default(?Closure $default): static
     {
         $this->default = $default;
+
+        return $this;
+    }
+
+    /**
+     * Set a literal default value for this field.
+     */
+    public function defaultLiteral(mixed $defaultLiteral): static
+    {
+        $this->default(fn(): mixed => $defaultLiteral);
 
         return $this;
     }

--- a/src/Schema/Concerns/SetsValue.php
+++ b/src/Schema/Concerns/SetsValue.php
@@ -49,21 +49,15 @@ trait SetsValue
     }
 
     /**
-     * Set a default value for this field via a callback.
+     * Set a default value for this field.
      */
-    public function default(?Closure $default): static
+    public function default(mixed $default): static
     {
+        if (!$default instanceof Closure) {
+            $default = fn() => $default;
+        }
+
         $this->default = $default;
-
-        return $this;
-    }
-
-    /**
-     * Set a literal default value for this field.
-     */
-    public function defaultLiteral(mixed $defaultLiteral): static
-    {
-        $this->default(fn(): mixed => $defaultLiteral);
 
         return $this;
     }

--- a/tests/feature/FieldDefaultTest.php
+++ b/tests/feature/FieldDefaultTest.php
@@ -17,7 +17,7 @@ class FieldDefaultTest extends AbstractTestCase
         $this->api = new JsonApi();
     }
 
-    public function test_default_value_used_if_field_not_present()
+    public function test_default_closure_value_used_if_field_not_present()
     {
         $this->api->resource(
             new MockResource(
@@ -52,7 +52,7 @@ class FieldDefaultTest extends AbstractTestCase
                 fields: [
                     Attribute::make('name')
                         ->writable()
-                        ->defaultLiteral('default'),
+                        ->default('default'),
                 ],
             ),
         );

--- a/tests/feature/FieldDefaultTest.php
+++ b/tests/feature/FieldDefaultTest.php
@@ -43,6 +43,32 @@ class FieldDefaultTest extends AbstractTestCase
         );
     }
 
+    public function test_default_literal_value_used_if_field_not_present()
+    {
+        $this->api->resource(
+            new MockResource(
+                'users',
+                endpoints: [Create::make()],
+                fields: [
+                    Attribute::make('name')
+                        ->writable()
+                        ->defaultLiteral('default'),
+                ],
+            ),
+        );
+
+        $response = $this->api->handle(
+            $this->buildRequest('POST', '/users')->withParsedBody([
+                'data' => ['type' => 'users'],
+            ]),
+        );
+
+        $this->assertJsonApiDocumentSubset(
+            ['data' => ['attributes' => ['name' => 'default']]],
+            $response->getBody(),
+        );
+    }
+
     public function test_default_value_not_used_if_field_present()
     {
         $this->api->resource(


### PR DESCRIPTION
Hi,

I propose to add a convenience method to directly set a literal default value on fields, instead of using a callback. The callback is nice for scenario's like setting dynamic values based on the `Context`, but in a lot of cases we just want to set a default "hardcoded" value.

I've added a second method called `defaultLiteral()` so the choice between using a callback or a literal value is more explicit and there is less chance of accidental errors/bugs in my opinion. And I kept the original `default()` method so as to not introduce breaking changes. But I'm also open to other solutions if you prefer another approach.

However, I will be traveling the next two weeks and won't have access to my workstation so any changes you'd like you'll either have to implement yourself or wait for a couple of weeks. I will have access to my email/github to exchange messages though.

Thanks for the consideration!