### PR TITLE
Add array field

### DIFF
--- a/src/Schema/Field/ArrayField.php
+++ b/src/Schema/Field/ArrayField.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tobyz\JsonApiServer\Schema\Field;
+
+class ArrayField extends Field
+{
+    private int $minItems = 0;
+    private ?int $maxItems = null;
+    private bool $uniqueItems = false;
+
+    public function __construct(string $name)
+    {
+        parent::__construct($name);
+
+        $this->validate(function (mixed $value, callable $fail): void {
+            if ($value === null) {
+                return;
+            }
+
+            if (!is_array($value)) {
+                $fail('must be an array');
+                return;
+            }
+
+            if (count($value) < $this->minItems) {
+                $fail(sprintf('must contain at least %d values', $this->minItems));
+            }
+
+            if ($this->maxItems !== null && count($value) > $this->maxItems) {
+                $fail(sprintf('must contain no more than %d values', $this->maxItems));
+            }
+
+            if ($this->uniqueItems && $value !== array_unique($value)) {
+                $fail('must contain unique values');
+            }
+        });
+    }
+
+    public function minItems(int $minItems): static
+    {
+        $this->minItems = $minItems;
+
+        return $this;
+    }
+
+    public function maxItems(?int $maxItems): static
+    {
+        $this->maxItems = $maxItems;
+
+        return $this;
+    }
+
+    public function uniqueItems(bool $uniqueItems = true): static
+    {
+        $this->uniqueItems = $uniqueItems;
+
+        return $this;
+    }
+}

--- a/src/Schema/Field/ArrayField.php
+++ b/src/Schema/Field/ArrayField.php
@@ -38,12 +38,8 @@ class ArrayField extends Field
             }
 
             if ($this->items) {
-                foreach ($value as $position => $item) {
-                    $itemFail = function ($detail = null) use ($fail, $position) {
-                        $fail('item at position ' . $position . ' ' . $detail);
-                    };
-
-                    $this->items->validateValue($item, $itemFail, $context);
+                foreach ($value as $item) {
+                    $this->items->validateValue($item, $fail, $context);
                 }
             }
         });

--- a/src/Schema/Field/ArrayField.php
+++ b/src/Schema/Field/ArrayField.php
@@ -72,4 +72,15 @@ class ArrayField extends Field
 
         return $this;
     }
+
+    public function getSchema(): array
+    {
+        return parent::getSchema() + [
+            'type' => 'array',
+            'minItems' => $this->minItems,
+            'maxItems' => $this->maxItems,
+            'uniqueItems' => $this->uniqueItems,
+            'items' => $this->items?->getSchema(),
+        ];
+    }
 }

--- a/src/Schema/Field/ArrayField.php
+++ b/src/Schema/Field/ArrayField.php
@@ -43,7 +43,7 @@ class ArrayField extends Field
                         $fail('item at position ' . $position . ' ' . $detail);
                     };
 
-                    $this->items->validateValue($itemFail, $fail, $context);
+                    $this->items->validateValue($item, $itemFail, $context);
                 }
             }
         });

--- a/src/Schema/Field/ArrayField.php
+++ b/src/Schema/Field/ArrayField.php
@@ -2,17 +2,20 @@
 
 namespace Tobyz\JsonApiServer\Schema\Field;
 
+use Tobyz\JsonApiServer\Context;
+
 class ArrayField extends Field
 {
     private int $minItems = 0;
     private ?int $maxItems = null;
     private bool $uniqueItems = false;
+    private ?Attribute $items = null;
 
     public function __construct(string $name)
     {
         parent::__construct($name);
 
-        $this->validate(function (mixed $value, callable $fail): void {
+        $this->validate(function (mixed $value, callable $fail, Context $context): void {
             if ($value === null) {
                 return;
             }
@@ -32,6 +35,16 @@ class ArrayField extends Field
 
             if ($this->uniqueItems && $value !== array_unique($value)) {
                 $fail('must contain unique values');
+            }
+
+            if ($this->items) {
+                foreach ($value as $position => $item) {
+                    $itemFail = function ($detail = null) use ($fail, $position) {
+                        $fail('item at position ' . $position . ' ' . $detail);
+                    };
+
+                    $this->items->validateValue($itemFail, $fail, $context);
+                }
             }
         });
     }
@@ -53,6 +66,13 @@ class ArrayField extends Field
     public function uniqueItems(bool $uniqueItems = true): static
     {
         $this->uniqueItems = $uniqueItems;
+
+        return $this;
+    }
+
+    public function items(Attribute $schema): static
+    {
+        $this->items = $schema;
 
         return $this;
     }

--- a/tests/feature/ArrayFieldTest.php
+++ b/tests/feature/ArrayFieldTest.php
@@ -216,6 +216,12 @@ class ArrayFieldTest extends AbstractTestCase
                 'items' => [
                     'type' => 'string',
                     'enum' => ['valid1', 'valid2'],
+                    'description' => null,
+                    'nullable' => false,
+                    'minLength' => 0,
+                    'maxLength' => null,
+                    'pattern' => null,
+                    'format' => null,
                 ],
                 'description' => null,
                 'nullable' => false,

--- a/tests/feature/ArrayFieldTest.php
+++ b/tests/feature/ArrayFieldTest.php
@@ -136,7 +136,7 @@ class ArrayFieldTest extends AbstractTestCase
         );
     }
 
-    public function test_invalid_item_schema()
+    public function test_invalid_items()
     {
         $this->api->resource(
             new MockResource(
@@ -162,7 +162,7 @@ class ArrayFieldTest extends AbstractTestCase
         );
     }
 
-    public function test_valid_item_schema()
+    public function test_valid_items()
     {
         $this->api->resource(
             new MockResource(
@@ -189,6 +189,43 @@ class ArrayFieldTest extends AbstractTestCase
             ['data' => ['attributes' => ['featureToggles' => ['valid1', 'valid2']]]],
             $response->getBody(),
             true,
+        );
+    }
+
+    public function test_schema()
+    {
+        $this->assertEquals(
+            [
+                'type' => 'array',
+                'minItems' => 0,
+                'maxItems' => null,
+                'uniqueItems' => false,
+                'items' => null,
+            ],
+            ArrayField::make('featureToggles')
+                ->getSchema(),
+        );
+
+        $this->assertEquals(
+            [
+                'type' => 'array',
+                'minItems' => 1,
+                'maxItems' => 10,
+                'uniqueItems' => true,
+                'items' => [
+                    'type' => 'string',
+                    'enum' => ['valid1', 'valid2'],
+                ],
+            ],
+            ArrayField::make('featureToggles')
+                ->minItems(1)
+                ->maxItems(10)
+                ->uniqueItems()
+                ->items(
+                    Str::make('')
+                        ->enum(['valid1', 'valid2'])
+                )
+                ->getSchema(),
         );
     }
 }

--- a/tests/feature/ArrayFieldTest.php
+++ b/tests/feature/ArrayFieldTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tobyz\Tests\JsonApiServer\feature;
+
+use Tobyz\JsonApiServer\Endpoint\Create;
+use Tobyz\JsonApiServer\Exception\UnprocessableEntityException;
+use Tobyz\JsonApiServer\JsonApi;
+use Tobyz\JsonApiServer\Schema\Field\ArrayField;
+use Tobyz\Tests\JsonApiServer\AbstractTestCase;
+use Tobyz\Tests\JsonApiServer\MockResource;
+
+class ArrayFieldTest extends AbstractTestCase
+{
+    private JsonApi $api;
+
+    public function setUp(): void
+    {
+        $this->api = new JsonApi();
+    }
+
+    public function test_validates_array()
+    {
+        $this->api->resource(
+            new MockResource(
+                'customers',
+                endpoints: [Create::make()],
+                fields: [
+                    ArrayField::make('featureToggles')
+                        ->writable(),
+                ],
+            ),
+        );
+
+        $this->expectException(UnprocessableEntityException::class);
+
+        $this->api->handle(
+            $this->buildRequest('POST', '/customers')->withParsedBody([
+                'data' => ['type' => 'customers', 'attributes' => ['featureToggles' => 1]],
+            ]),
+        );
+    }
+
+    public function test_invalid_min_length()
+    {
+        $this->api->resource(
+            new MockResource(
+                'customers',
+                endpoints: [Create::make()],
+                fields: [
+                    ArrayField::make('featureToggles')
+                        ->minItems(1)
+                        ->writable(),
+                ],
+            ),
+        );
+
+        $this->expectException(UnprocessableEntityException::class);
+
+        $this->api->handle(
+            $this->buildRequest('POST', '/customers')->withParsedBody([
+                'data' => ['type' => 'customers', 'attributes' => ['featureToggles' => []]],
+            ]),
+        );
+    }
+
+    public function test_invalid_max_length()
+    {
+        $this->api->resource(
+            new MockResource(
+                'customers',
+                endpoints: [Create::make()],
+                fields: [
+                    ArrayField::make('featureToggles')
+                        ->maxItems(1)
+                        ->writable(),
+                ],
+            ),
+        );
+
+        $this->expectException(UnprocessableEntityException::class);
+
+        $this->api->handle(
+            $this->buildRequest('POST', '/customers')->withParsedBody([
+                'data' => ['type' => 'customers', 'attributes' => ['featureToggles' => [1, 2]]],
+            ]),
+        );
+    }
+
+    public function test_invalid_uniqueness()
+    {
+        $this->api->resource(
+            new MockResource(
+                'customers',
+                endpoints: [Create::make()],
+                fields: [
+                    ArrayField::make('featureToggles')
+                        ->uniqueItems()
+                        ->writable(),
+                ],
+            ),
+        );
+
+        $this->expectException(UnprocessableEntityException::class);
+
+        $this->api->handle(
+            $this->buildRequest('POST', '/customers')->withParsedBody([
+                'data' => ['type' => 'customers', 'attributes' => ['featureToggles' => [1, 1]]],
+            ]),
+        );
+    }
+
+    public function test_valid_items_constraints()
+    {
+        $this->api->resource(
+            new MockResource(
+                'customers',
+                endpoints: [Create::make()],
+                fields: [
+                    ArrayField::make('featureToggles')
+                        ->minItems(2)
+                        ->maxItems(4)
+                        ->uniqueItems()
+                        ->writable(),
+                ],
+            ),
+        );
+
+        $response = $this->api->handle(
+            $this->buildRequest('POST', '/customers')->withParsedBody([
+                'data' => ['type' => 'customers', 'attributes' => ['featureToggles' => [1, 2, 3]]],
+            ]),
+        );
+
+        $this->assertJsonApiDocumentSubset(
+            ['data' => ['attributes' => ['featureToggles' => [1, 2, 3]]]],
+            $response->getBody(),
+            true,
+        );
+    }
+}

--- a/tests/feature/ArrayFieldTest.php
+++ b/tests/feature/ArrayFieldTest.php
@@ -201,6 +201,8 @@ class ArrayFieldTest extends AbstractTestCase
                 'maxItems' => null,
                 'uniqueItems' => false,
                 'items' => null,
+                'description' => null,
+                'nullable' => false,
             ],
             ArrayField::make('featureToggles')
                 ->getSchema(),
@@ -216,6 +218,8 @@ class ArrayFieldTest extends AbstractTestCase
                     'type' => 'string',
                     'enum' => ['valid1', 'valid2'],
                 ],
+                'description' => null,
+                'nullable' => false,
             ],
             ArrayField::make('featureToggles')
                 ->minItems(1)


### PR DESCRIPTION
This implements the array field discussed in #87 .

@tobyzerner a couple of things to keep in mind:

- `Array` and `List` are reserved keywords in PHP and cannot be used as class names. I've temporarily used `ArrayField` as class name. Other possibilities are `ArrayList`, `Arr` (like `Str`), ... but I'm not a big fan of those either. I'll leave it up to you to decide on this.
- I've only handled the validation. If you think the class should also define some other default methods like `serialize()`, `deserialize()`, etc let me know how you think they should behave. For my own use case the `validation()` was enough (at first glance).
- The JSON pointer in errors regarding the `items` schema is now always the JSON pointer of the array property, while it should ideally be suffixed with `/0`, `/1`, ... (depending on the position of the item that is invalid). I didn't see a quick way to implement this, I think you may need to investigate this and adapt the error handling to deal with this.
- As discussed the field injected into `items()` now also still requires a name. In the tests and my own app I've just used an empty string for now.