### PR TITLE
feat: allow including relationships by default

### DIFF
--- a/src/Endpoint/Concerns/IncludesData.php
+++ b/src/Endpoint/Concerns/IncludesData.php
@@ -4,13 +4,23 @@ namespace Tobyz\JsonApiServer\Endpoint\Concerns;
 
 use Tobyz\JsonApiServer\Context;
 use Tobyz\JsonApiServer\Exception\BadRequestException;
+use Tobyz\JsonApiServer\Resource\Resource;
 use Tobyz\JsonApiServer\Schema\Field\Relationship;
 
 trait IncludesData
 {
+    protected ?array $defaultInclude = null;
+
+    public function defaultInclude(array $include): static
+    {
+        $this->defaultInclude = $include;
+
+        return $this;
+    }
+
     private function getInclude(Context $context): array
     {
-        if ($includeString = $context->request->getQueryParams()['include'] ?? null) {
+        if ($includeString = $context->request->getQueryParams()['include'] ?? $this->defaultInclude) {
             $include = $this->parseInclude($includeString);
 
             $this->validateInclude(

--- a/src/Endpoint/Concerns/IncludesData.php
+++ b/src/Endpoint/Concerns/IncludesData.php
@@ -20,7 +20,9 @@ trait IncludesData
 
     private function getInclude(Context $context): array
     {
-        if ($includeString = $context->request->getQueryParams()['include'] ?? $this->defaultInclude) {
+        if (
+            $includeString = $context->request->getQueryParams()['include'] ?? $this->defaultInclude
+        ) {
             $include = $this->parseInclude($includeString);
 
             $this->validateInclude(

--- a/src/Endpoint/Concerns/IncludesData.php
+++ b/src/Endpoint/Concerns/IncludesData.php
@@ -4,7 +4,6 @@ namespace Tobyz\JsonApiServer\Endpoint\Concerns;
 
 use Tobyz\JsonApiServer\Context;
 use Tobyz\JsonApiServer\Exception\BadRequestException;
-use Tobyz\JsonApiServer\Resource\Resource;
 use Tobyz\JsonApiServer\Schema\Field\Relationship;
 
 trait IncludesData


### PR DESCRIPTION
Hello 👋🏼,

This is a beautifully written package, it has been great working with 🙏🏼.

We have come across a use case where we need some relations included by default. We currently *have* to maintain a fork of our own due to some very unique edge case behavior that probably don't make sense having in the origin repository.

I am not sure if you would want to support default includes, but thought I'd send this your way just in case. Will probably push more for other changes that might make sense to contribute back as well.

---

This would work per endpoint:

```php
Endpoint\Show::make()
    ->defaultInclude(['groups', 'actor'])
```