### PR TITLE
feat: MorphTo serialization

### DIFF
--- a/src/Laravel/EloquentResource.php
+++ b/src/Laravel/EloquentResource.php
@@ -77,18 +77,13 @@ abstract class EloquentResource extends AbstractResource implements
             // related model with the value of the ID filled.
             if ($relation instanceof BelongsTo && $context->include === null) {
                 if ($key = $model->getAttribute($relation->getForeignKeyName())) {
-                    $related = null;
-
                     if ($relation instanceof MorphTo) {
                         $morphType = $model->{$relation->getMorphType()};
                         $morphType = MorphTo::getMorphedModel($morphType) ?? $morphType;
-
-                        if (class_exists($morphType)) {
-                            $related = new $morphType();
-                        }
+                        $related = $relation->createModelByType($morphType);
+                    } else {
+                        $related = $relation->getRelated();
                     }
-
-                    $related ??= $relation->getRelated();
 
                     return $related->newInstance()->forceFill([$related->getKeyName() => $key]);
                 }

--- a/src/Laravel/EloquentResource.php
+++ b/src/Laravel/EloquentResource.php
@@ -79,7 +79,6 @@ abstract class EloquentResource extends AbstractResource implements
                 if ($key = $model->getAttribute($relation->getForeignKeyName())) {
                     if ($relation instanceof MorphTo) {
                         $morphType = $model->{$relation->getMorphType()};
-                        $morphType = MorphTo::getMorphedModel($morphType) ?? $morphType;
                         $related = $relation->createModelByType($morphType);
                     } else {
                         $related = $relation->getRelated();

--- a/src/Laravel/EloquentResource.php
+++ b/src/Laravel/EloquentResource.php
@@ -84,7 +84,7 @@ abstract class EloquentResource extends AbstractResource implements
                         $morphType = MorphTo::getMorphedModel($morphType) ?? $morphType;
 
                         if (class_exists($morphType)) {
-                            $related = new $morphType;
+                            $related = new $morphType();
                         }
                     }
 


### PR DESCRIPTION
Hello 👋🏼,

When using a `MorphTo` relation, the `$relation->getRelated()` returns an instance of the parent model instead of the expected related model. So the serialization ends up using the wrong model class to find the appropriate resource class.