### PR TITLE
fix: error when attributes is null

### DIFF
--- a/src/Endpoint/Concerns/SavesData.php
+++ b/src/Endpoint/Concerns/SavesData.php
@@ -63,13 +63,19 @@ trait SavesData
             ))->setSource(['pointer' => '/data/type']);
         }
 
-        if (array_key_exists('attributes', $body['data']) && !is_array($body['data']['attributes'])) {
+        if (
+            array_key_exists('attributes', $body['data']) &&
+            !is_array($body['data']['attributes'])
+        ) {
             throw (new BadRequestException('data.attributes must be an object'))->setSource([
                 'pointer' => '/data/attributes',
             ]);
         }
 
-        if (array_key_exists('relationships', $body['data']) && !is_array($body['data']['relationships'])) {
+        if (
+            array_key_exists('relationships', $body['data']) &&
+            !is_array($body['data']['relationships'])
+        ) {
             throw (new BadRequestException('data.relationships must be an object'))->setSource([
                 'pointer' => '/data/relationships',
             ]);

--- a/src/Endpoint/Concerns/SavesData.php
+++ b/src/Endpoint/Concerns/SavesData.php
@@ -63,13 +63,13 @@ trait SavesData
             ))->setSource(['pointer' => '/data/type']);
         }
 
-        if (isset($body['data']['attributes']) && !is_array($body['data']['attributes'])) {
+        if (array_key_exists('attributes', $body['data']) && !is_array($body['data']['attributes'])) {
             throw (new BadRequestException('data.attributes must be an object'))->setSource([
                 'pointer' => '/data/attributes',
             ]);
         }
 
-        if (isset($body['data']['relationships']) && !is_array($body['data']['relationships'])) {
+        if (array_key_exists('relationships', $body['data']) && !is_array($body['data']['relationships'])) {
             throw (new BadRequestException('data.relationships must be an object'))->setSource([
                 'pointer' => '/data/relationships',
             ]);


### PR DESCRIPTION
If for whatever reason a request has the attributes value as `null` (or relationships value). a PHP error is thrown where the code expects it to be an array.

```http
POST /records

{
  "data": {
    "type": "records",
    "attributes": null
  }
}
```