### PR TITLE
fix: allow invalid nested includes for morph

### DIFF
--- a/src/Endpoint/Concerns/IncludesData.php
+++ b/src/Endpoint/Concerns/IncludesData.php
@@ -72,12 +72,18 @@ trait IncludesData
                     ? array_map(fn($type) => $context->api->getResource($type), $types)
                     : array_values($context->api->resources);
 
-                $this->validateInclude($context, $relatedResources, $nested, $name . '.', $allowInvalid || $field->collection);
+                $this->validateInclude(
+                    $context,
+                    $relatedResources,
+                    $nested,
+                    $name . '.',
+                    $allowInvalid || $field->collection,
+                );
 
                 continue 2;
             }
 
-            if (! $allowInvalid) {
+            if (!$allowInvalid) {
                 throw (new BadRequestException("Invalid include [$path$name]"))->setSource([
                     'parameter' => 'include',
                 ]);

--- a/src/Endpoint/Concerns/IncludesData.php
+++ b/src/Endpoint/Concerns/IncludesData.php
@@ -52,6 +52,7 @@ trait IncludesData
         array $resources,
         array $include,
         string $path = '',
+        bool $allowInvalid = false,
     ): void {
         foreach ($include as $name => $nested) {
             foreach ($resources as $resource) {
@@ -71,14 +72,16 @@ trait IncludesData
                     ? array_map(fn($type) => $context->api->getResource($type), $types)
                     : array_values($context->api->resources);
 
-                $this->validateInclude($context, $relatedResources, $nested, $name . '.');
+                $this->validateInclude($context, $relatedResources, $nested, $name . '.', $allowInvalid || $field->collection);
 
                 continue 2;
             }
 
-            throw (new BadRequestException("Invalid include [$path$name]"))->setSource([
-                'parameter' => 'include',
-            ]);
+            if (! $allowInvalid) {
+                throw (new BadRequestException("Invalid include [$path$name]"))->setSource([
+                    'parameter' => 'include',
+                ]);
+            }
         }
     }
 }

--- a/src/Schema/Field/Relationship.php
+++ b/src/Schema/Field/Relationship.php
@@ -15,6 +15,7 @@ abstract class Relationship extends Field
     public array $collections;
     public bool $includable = false;
     public bool $linkage = false;
+    public bool $collection = false;
 
     /**
      * Set the collection(s) that this relationship is to.
@@ -22,6 +23,7 @@ abstract class Relationship extends Field
     public function collection(string|array $type): static
     {
         $this->collections = (array) $type;
+        $this->collection = true;
 
         return $this;
     }
@@ -31,7 +33,10 @@ abstract class Relationship extends Field
      */
     public function type(string|array $type): static
     {
-        return $this->collection($type);
+        $this->collections = (array) $type;
+        $this->collection = count($this->collections) > 1;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Hello 👋🏼,

This PR allows the scenario where you have a morph relationship (collection of resources on a relationship) and you include a nested relationship which only exists on one of the resources from the collection.

Prior to the changes here, that would not be possible and an exception would be thrown.

**For example:**

If you have a morph relation `subject` of types (`users`, `posts`)  and only `posts` has the relation `author`. Including `subjet.author` would not be possible.