### PR TITLE
feat: allow limiting `ToMany` relationships

### DIFF
--- a/src/Laravel/EloquentBuffer.php
+++ b/src/Laravel/EloquentBuffer.php
@@ -57,12 +57,21 @@ abstract class EloquentBuffer
                     $modelClass = get_class($resource->newModel($context));
 
                     if ($resource instanceof EloquentResource && !isset($constrain[$modelClass])) {
-                        $constrain[$modelClass] = function ($query) use ($resource, $context, $relationship, $relation) {
+                        $constrain[$modelClass] = function ($query) use (
+                            $resource,
+                            $context,
+                            $relationship,
+                            $relation,
+                        ) {
                             $resource->scope($query, $context);
 
                             // Limiting relationship results is only possible on Laravel 11 or later,
                             // or if the model uses the \Staudenmeir\EloquentEagerLimit\HasEagerLimit trait.
-                            if ($relationship instanceof ToMany && method_exists($relation, 'limit') && ! empty($relationship->limit)) {
+                            if (
+                                $relationship instanceof ToMany &&
+                                method_exists($relation, 'limit') &&
+                                !empty($relationship->limit)
+                            ) {
                                 $relation->limit($relationship->limit);
                             }
                         };

--- a/src/Schema/Field/ToMany.php
+++ b/src/Schema/Field/ToMany.php
@@ -8,11 +8,20 @@ use Tobyz\JsonApiServer\Exception\Sourceable;
 
 class ToMany extends Relationship
 {
+    public ?int $limit = null;
+
     public function __construct(string $name)
     {
         parent::__construct($name);
 
         $this->type($name);
+    }
+
+    public function limit(?int $limit): static
+    {
+        $this->limit = $limit;
+
+        return $this;
     }
 
     public function serializeValue($value, Context $context): mixed


### PR DESCRIPTION
The https://github.com/staudenmeir/eloquent-eager-limit package allows limiting relationship results, Laravel 11 will officially support this: https://github.com/laravel/framework/pull/49695.

This PR adds support for the feature, allowing `ToMany` relationships to be limited by simply passing `->limit(6)`, this is especially useful when all that's needed is a subset of results, which is a great performance improvement.