### PR TITLE
feat: allow constraining `ToMany` query

### DIFF
--- a/src/Laravel/EloquentBuffer.php
+++ b/src/Laravel/EloquentBuffer.php
@@ -57,7 +57,11 @@ abstract class EloquentBuffer
                     $modelClass = get_class($resource->newModel($context));
 
                     if ($resource instanceof EloquentResource && !isset($constrain[$modelClass])) {
-                        $constrain[$modelClass] = function ($query) use ($resource, $context, $relationship) {
+                        $constrain[$modelClass] = function ($query) use (
+                            $resource,
+                            $context,
+                            $relationship,
+                        ) {
                             $resource->scope($query, $context);
 
                             if ($relationship instanceof ToMany && $relationship->constrain) {

--- a/src/Laravel/EloquentBuffer.php
+++ b/src/Laravel/EloquentBuffer.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Tobyz\JsonApiServer\Context;
 use Tobyz\JsonApiServer\Schema\Field\Relationship;
+use Tobyz\JsonApiServer\Schema\Field\ToMany;
 
 abstract class EloquentBuffer
 {
@@ -56,7 +57,13 @@ abstract class EloquentBuffer
                     $modelClass = get_class($resource->newModel($context));
 
                     if ($resource instanceof EloquentResource && !isset($constrain[$modelClass])) {
-                        $constrain[$modelClass] = fn($query) => $resource->scope($query, $context);
+                        $constrain[$modelClass] = function ($query) use ($resource, $context, $relationship) {
+                            $resource->scope($query, $context);
+
+                            if ($relationship instanceof ToMany && $relationship->constrain) {
+                                ($relationship->constrain)($query, $context);
+                            }
+                        };
                     }
                 }
 

--- a/src/Laravel/EloquentBuffer.php
+++ b/src/Laravel/EloquentBuffer.php
@@ -6,8 +6,9 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Tobyz\JsonApiServer\Context;
+use Tobyz\JsonApiServer\Laravel\Field\ToMany;
+use Tobyz\JsonApiServer\Laravel\Field\ToOne;
 use Tobyz\JsonApiServer\Schema\Field\Relationship;
-use Tobyz\JsonApiServer\Schema\Field\ToMany;
 
 abstract class EloquentBuffer
 {
@@ -64,8 +65,8 @@ abstract class EloquentBuffer
                         ) {
                             $resource->scope($query, $context);
 
-                            if ($relationship instanceof ToMany && $relationship->constrain) {
-                                ($relationship->constrain)($query, $context);
+                            if (($relationship instanceof ToMany || $relationship instanceof ToOne) && $relationship->scope) {
+                                ($relationship->scope)($query, $context);
                             }
                         };
                     }

--- a/src/Laravel/EloquentBuffer.php
+++ b/src/Laravel/EloquentBuffer.php
@@ -65,7 +65,11 @@ abstract class EloquentBuffer
                         ) {
                             $resource->scope($query, $context);
 
-                            if (($relationship instanceof ToMany || $relationship instanceof ToOne) && $relationship->scope) {
+                            if (
+                                ($relationship instanceof ToMany ||
+                                    $relationship instanceof ToOne) &&
+                                $relationship->scope
+                            ) {
                                 ($relationship->scope)($query, $context);
                             }
                         };

--- a/src/Laravel/Field/Concerns/ScopesRelationship.php
+++ b/src/Laravel/Field/Concerns/ScopesRelationship.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tobyz\JsonApiServer\Laravel\Field\Concerns;
+
+use Closure;
+
+trait ScopesRelationship
+{
+    public ?Closure $scope = null;
+
+    public function scope(?Closure $scope): static
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+}

--- a/src/Laravel/Field/ToMany.php
+++ b/src/Laravel/Field/ToMany.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tobyz\JsonApiServer\Laravel\Field;
+
+use Tobyz\JsonApiServer\Schema\Field\ToMany as BaseToMany;
+
+class ToMany extends BaseToMany
+{
+    use Concerns\ScopesRelationship;
+}

--- a/src/Laravel/Field/ToOne.php
+++ b/src/Laravel/Field/ToOne.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tobyz\JsonApiServer\Laravel\Field;
+
+use Tobyz\JsonApiServer\Schema\Field\ToOne as BaseToOne;
+
+class ToOne extends BaseToOne
+{
+    use Concerns\ScopesRelationship;
+}

--- a/src/Schema/Field/ToMany.php
+++ b/src/Schema/Field/ToMany.php
@@ -2,17 +2,27 @@
 
 namespace Tobyz\JsonApiServer\Schema\Field;
 
+use Closure;
 use Tobyz\JsonApiServer\Context;
 use Tobyz\JsonApiServer\Exception\BadRequestException;
 use Tobyz\JsonApiServer\Exception\Sourceable;
 
 class ToMany extends Relationship
 {
+    public ?Closure $constrain = null;
+
     public function __construct(string $name)
     {
         parent::__construct($name);
 
         $this->type($name);
+    }
+
+    public function constrain(?Closure $constrain): static
+    {
+        $this->constrain = $constrain;
+
+        return $this;
     }
 
     public function serializeValue($value, Context $context): mixed

--- a/src/Schema/Field/ToMany.php
+++ b/src/Schema/Field/ToMany.php
@@ -9,20 +9,11 @@ use Tobyz\JsonApiServer\Exception\Sourceable;
 
 class ToMany extends Relationship
 {
-    public ?Closure $constrain = null;
-
     public function __construct(string $name)
     {
         parent::__construct($name);
 
         $this->type($name);
-    }
-
-    public function constrain(?Closure $constrain): static
-    {
-        $this->constrain = $constrain;
-
-        return $this;
     }
 
     public function serializeValue($value, Context $context): mixed


### PR DESCRIPTION
A better alternative to #102, generally allowing to constrain the relationship query during eager load is more flexible for use cases like the one outlined in the stale PR.