### PR TITLE
chore: allow mutation of resource fields

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -90,7 +90,7 @@ class Context
 
         $fields = [];
 
-        foreach ($resource->fields() as $field) {
+        foreach ($resource->resolveFields() as $field) {
             $fields[$field->name] = $field;
         }
 

--- a/src/Endpoint/Index.php
+++ b/src/Endpoint/Index.php
@@ -132,7 +132,7 @@ class Index implements Endpoint
             return;
         }
 
-        $sorts = $context->collection->sorts();
+        $sorts = $context->collection->resolveSorts();
 
         foreach (parse_sort_string($sortString) as [$name, $direction]) {
             foreach ($sorts as $field) {

--- a/src/JsonApi.php
+++ b/src/JsonApi.php
@@ -122,7 +122,7 @@ class JsonApi implements RequestHandlerInterface
 
             $context = $context->withCollection($this->getCollection($segments[0]));
 
-            foreach ($context->collection->endpoints() as $endpoint) {
+            foreach ($context->collection->resolveEndpoints() as $endpoint) {
                 try {
                     if ($response = $endpoint->handle($context->withEndpoint($endpoint))) {
                         break;

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -27,9 +27,19 @@ abstract class AbstractResource implements Resource, Collection
         return [];
     }
 
+    public function resolveEndpoints(): array
+    {
+        return $this->endpoints();
+    }
+
     public function fields(): array
     {
         return [];
+    }
+
+    public function resolveFields(): array
+    {
+        return $this->fields();
     }
 
     public function meta(): array
@@ -42,9 +52,19 @@ abstract class AbstractResource implements Resource, Collection
         return [];
     }
 
+    public function resolveFilters(): array
+    {
+        return $this->filters();
+    }
+
     public function sorts(): array
     {
         return [];
+    }
+
+    public function resolveSorts(): array
+    {
+        return $this->sorts();
     }
 
     public function getId(object $model, Context $context): string

--- a/src/Resource/Collection.php
+++ b/src/Resource/Collection.php
@@ -26,5 +26,5 @@ interface Collection
     /**
      * The collection's endpoints.
      */
-    public function endpoints(): array;
+    public function resolveEndpoints(): array;
 }

--- a/src/Resource/Listable.php
+++ b/src/Resource/Listable.php
@@ -23,12 +23,12 @@ interface Listable
      *
      * @return Filter[]
      */
-    public function filters(): array;
+    public function resolveFilters(): array;
 
     /**
      * Sorts that can be applied to the resource list.
      *
      * @return Sort[]
      */
-    public function sorts(): array;
+    public function resolveSorts(): array;
 }

--- a/src/Resource/Resource.php
+++ b/src/Resource/Resource.php
@@ -18,7 +18,7 @@ interface Resource
      *
      * @return Field[]
      */
-    public function fields(): array;
+    public function resolveFields(): array;
 
     /**
      * Get the meta attributes for this resource.

--- a/src/functions.php
+++ b/src/functions.php
@@ -78,7 +78,7 @@ function apply_filters(
     Context $context,
 ): void {
     $context = $context->withCollection($collection);
-    $availableFilters = $collection->filters();
+    $availableFilters = $collection->resolveFilters();
 
     foreach ($filters as $name => $value) {
         foreach ($availableFilters as $filter) {

--- a/tests/MockCollection.php
+++ b/tests/MockCollection.php
@@ -40,17 +40,17 @@ class MockCollection implements Collection, Listable, Paginatable
         return null;
     }
 
-    public function endpoints(): array
+    public function resolveEndpoints(): array
     {
         return $this->endpoints;
     }
 
-    public function filters(): array
+    public function resolveFilters(): array
     {
         return $this->filters;
     }
 
-    public function sorts(): array
+    public function resolveSorts(): array
     {
         return $this->sorts;
     }


### PR DESCRIPTION
Hello 👋🏼,

We have use case where a resource's different fields (namely: fields, endpoints and sorts) need to be extendable (addable, removable, mutatable).

This is only possible if the different methods go through one additional internal call that could enable mutation before caching and returning the final sets.

Of course, totally understandable if this change isn't deemed appropriate for the package.

Alson, this is the trait we are using for this (let me know if it's something that could be useful in the package as well) https://github.com/flarum/framework/blob/sm/json-api-server/framework/core/src/Api/Resource/Concerns/Extendable.php

Thanks!