### PR TITLE
feat: allow overriding the validation process

### DIFF
--- a/src/Endpoint/Concerns/SavesData.php
+++ b/src/Endpoint/Concerns/SavesData.php
@@ -154,7 +154,7 @@ trait SavesData
      *
      * @throws UnprocessableEntityException if any fields do not pass validation.
      */
-    private function assertDataValid(Context $context, array $data, bool $validateAll): void
+    protected function assertDataValid(Context $context, array $data, bool $validateAll): void
     {
         $errors = [];
 


### PR DESCRIPTION
Hello 👋🏼,

In our use case we wish to validate all the fields together to enable certain validation capabilities in `illuminate/validation` (such as `required_with`). But also, we want to [entirely rely on `illuminate/validation`](https://github.com/flarum/json-api-server/blob/main/src/Schema/Concerns/HasValidationRules.php). 

Opening up the `assertDataValid` for overriding would [allow for this to be possible](https://github.com/flarum/json-api-server/blob/main/src/Endpoint/Concerns/ValidatesData.php#L20).