### PR TITLE
fix: assigning null to non-null `$path`

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -21,7 +21,7 @@ class Context
     public ?array $include = null;
 
     private ?array $body;
-    private string $path;
+    private ?string $path;
 
     private WeakMap $fields;
     private WeakMap $sparseFields;


### PR DESCRIPTION
Fixes an issue when using the `$context->withRequest` method. The method fails because it attempts to assign a `null` value to string property `$path`.