### PR TITLE
feat: flexible endpoint context

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -3,6 +3,7 @@
 namespace Tobyz\JsonApiServer;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Tobyz\JsonApiServer\Endpoint\Create;
 use Tobyz\JsonApiServer\Endpoint\Endpoint;
 use Tobyz\JsonApiServer\Resource\Collection;
 use Tobyz\JsonApiServer\Resource\Resource;
@@ -211,5 +212,10 @@ class Context
         $new = clone $this;
         $new->include = $include;
         return $new;
+    }
+
+    public function creating(): bool
+    {
+        return $this->endpoint instanceof Create;
     }
 }

--- a/src/Schema/Concerns/SetsValue.php
+++ b/src/Schema/Concerns/SetsValue.php
@@ -33,7 +33,7 @@ trait SetsValue
      */
     public function writableOnCreate(): static
     {
-        $this->writable = fn($model, Context $context) => $context->endpoint instanceof Create;
+        $this->writable = fn($model, Context $context) => $context->creating();
 
         return $this;
     }


### PR DESCRIPTION
Isolating the checking of the current CRUD context into the context object can be helpful in our case since we implement our own separate Create endpoint class that does not extend the default one.

Understandable if not fit here.