### PR TITLE
feat: conditional linkage

### DIFF
--- a/src/Schema/Field/ToMany.php
+++ b/src/Schema/Field/ToMany.php
@@ -20,7 +20,7 @@ class ToMany extends Relationship
     {
         $meta = $this->serializeMeta($context);
 
-        if ((($context->include === null && !$this->linkage) || $value === null) && !$meta) {
+        if ((($context->include === null && !$this->hasLinkage($context)) || $value === null) && !$meta) {
             return null;
         }
 

--- a/src/Schema/Field/ToMany.php
+++ b/src/Schema/Field/ToMany.php
@@ -20,7 +20,10 @@ class ToMany extends Relationship
     {
         $meta = $this->serializeMeta($context);
 
-        if ((($context->include === null && !$this->hasLinkage($context)) || $value === null) && !$meta) {
+        if (
+            (($context->include === null && !$this->hasLinkage($context)) || $value === null) &&
+            !$meta
+        ) {
             return null;
         }
 

--- a/src/Schema/Field/ToOne.php
+++ b/src/Schema/Field/ToOne.php
@@ -26,7 +26,7 @@ class ToOne extends Relationship
     {
         $meta = $this->serializeMeta($context);
 
-        if ($context->include === null && !$this->linkage && !$meta) {
+        if ($context->include === null && !$this->hasLinkage($context) && !$meta) {
             return null;
         }
 


### PR DESCRIPTION
We have a use case where we need to enable linkage for a ToMany relation, but only when the Show endpoint is related to the resource itself and not another (another can be when inclusion is in effect instead).

So we do something along the lines of

```php
ToMany::make('posts')
    ->withLinkage(function (Context $context) {
          return $context->showing(self::class);
     })
```