### PR TITLE
fix: limiting ToMany relation results

### DIFF
--- a/src/Laravel/EloquentBuffer.php
+++ b/src/Laravel/EloquentBuffer.php
@@ -62,6 +62,7 @@ abstract class EloquentBuffer
                             $resource,
                             $context,
                             $relationship,
+                            $relation
                         ) {
                             $resource->scope($query, $context);
 
@@ -70,7 +71,7 @@ abstract class EloquentBuffer
                                     $relationship instanceof ToOne) &&
                                 $relationship->scope
                             ) {
-                                ($relationship->scope)($query, $context);
+                                ($relationship->scope)($relation, $context);
                             }
                         };
                     }

--- a/src/Laravel/EloquentBuffer.php
+++ b/src/Laravel/EloquentBuffer.php
@@ -62,7 +62,7 @@ abstract class EloquentBuffer
                             $resource,
                             $context,
                             $relationship,
-                            $relation
+                            $relation,
                         ) {
                             $resource->scope($query, $context);
 


### PR DESCRIPTION
I made a mistake in #103 where in order to be able to make use Laravel 11's many relationship limit, the object has to be the relation instead of the eloquent query.

Not sure if this constitutes a breaking change since there haven't been any releases in the package since then?

