### PR TITLE
Fix `multipleOf` bugs in Number type

### DIFF
--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -50,7 +50,7 @@ class Number implements Type
             }
         }
 
-        if ($this->multipleOf !== null && $value % $this->multipleOf !== 0) {
+        if ($this->multipleOf !== null && (float) $value !== 0.0 && $value % $this->multipleOf !== 0) {
             $fail(sprintf('must be a multiple of %d', $this->multipleOf));
         }
     }
@@ -85,7 +85,7 @@ class Number implements Type
 
     public function multipleOf(?float $number): static
     {
-        if ($number <= 0) {
+        if ($number !== null && $number <= 0) {
             throw new InvalidArgumentException('multipleOf must be a positive number');
         }
 

--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -50,7 +50,11 @@ class Number implements Type
             }
         }
 
-        if ($this->multipleOf !== null && (float) $value !== 0.0 && $value % $this->multipleOf !== 0) {
+        if (
+            $this->multipleOf !== null &&
+            (float) $value !== 0.0 &&
+            $value % $this->multipleOf !== 0
+        ) {
             $fail(sprintf('must be a multiple of %d', $this->multipleOf));
         }
     }


### PR DESCRIPTION
Fixes the multipleOf validation crashing when trying to use the modulo operator on a value that is zero, and an InvalidArgumentException when calling multipleOf() with `null` to reset it.

Edit: To clarify, `0` is considered to be a multiple of any `multipleOf` value by JSON schema, see for example https://www.jsonschemavalidator.net/s/lPabCUQd. This is also confirmed on https://www.learnjsonschema.com/2020-12/validation/multipleof/ (See examples: "Valid - 0 is a multiple of 4.1")