### PR TITLE
Fix `multipleOf` bugs

### DIFF
--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -59,7 +59,7 @@ class Number implements Type
             $this->multipleOf !== null &&
             (float) ($value / $this->multipleOf) !== round($value / $this->multipleOf)
         ) {
-            $fail(sprintf('must be a multiple of %d', $this->multipleOf));
+            $fail(sprintf('must be a multiple of %s', $this->multipleOf));
         }
     }
 

--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -52,7 +52,10 @@ class Number implements Type
 
         // Divide the value by multipleOf instead of using the modulo operator to avoid bugs when using a multipleOf
         // that has decimal places. (Since the modulo operator converts the multipleOf to int)
-        if ($this->multipleOf !== null && $value/$this->multipleOf !== (float) round($value/$this->multipleOf)) {
+        if (
+            $this->multipleOf !== null &&
+            $value / $this->multipleOf !== (float) round($value / $this->multipleOf)
+        ) {
             $fail(sprintf('must be a multiple of %d', $this->multipleOf));
         }
     }

--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -90,7 +90,7 @@ class Number implements Type
 
     public function multipleOf(?float $number): static
     {
-        if ($number <= 0) {
+        if ($number !== null && $number <= 0) {
             throw new InvalidArgumentException('multipleOf must be a positive number');
         }
 

--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -52,9 +52,12 @@ class Number implements Type
 
         // Divide the value by multipleOf instead of using the modulo operator to avoid bugs when using a multipleOf
         // that has decimal places. (Since the modulo operator converts the multipleOf to int)
+        // Note that dividing two integers returns another integer if the result is a whole number. So to make the
+        // comparison work at all times we need to cast the result to float. Casting both to integer will not work
+        // as intended since then the result of the division would also be rounded.
         if (
             $this->multipleOf !== null &&
-            $value / $this->multipleOf !== round($value / $this->multipleOf)
+            (float) ($value / $this->multipleOf) !== round($value / $this->multipleOf)
         ) {
             $fail(sprintf('must be a multiple of %d', $this->multipleOf));
         }

--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -50,7 +50,9 @@ class Number implements Type
             }
         }
 
-        if ($this->multipleOf !== null && $value % $this->multipleOf !== 0) {
+        // Divide the value by multipleOf instead of using the modulo operator to avoid bugs when using a multipleOf
+        // that has decimal places. (Since the modulo operator converts the multipleOf to int)
+        if ($this->multipleOf !== null && $value/$this->multipleOf !== (float) round($value/$this->multipleOf)) {
             $fail(sprintf('must be a multiple of %d', $this->multipleOf));
         }
     }

--- a/src/Schema/Type/Number.php
+++ b/src/Schema/Type/Number.php
@@ -54,7 +54,7 @@ class Number implements Type
         // that has decimal places. (Since the modulo operator converts the multipleOf to int)
         if (
             $this->multipleOf !== null &&
-            $value / $this->multipleOf !== (float) round($value / $this->multipleOf)
+            $value / $this->multipleOf !== round($value / $this->multipleOf)
         ) {
             $fail(sprintf('must be a multiple of %d', $this->multipleOf));
         }

--- a/tests/unit/NumberTest.php
+++ b/tests/unit/NumberTest.php
@@ -40,6 +40,10 @@ class NumberTest extends AbstractTestCase
             [Number::make()->maximum(10, exclusive: true), 10, false],
             [Number::make()->multipleOf(2), 1, false],
             [Number::make()->multipleOf(2), 2, true],
+            [Number::make()->multipleOf(0.01), 100, true],
+            [Number::make()->multipleOf(0.01), 100.5, true],
+            [Number::make()->multipleOf(0.01), 100.56, true],
+            [Number::make()->multipleOf(0.01), 100.567, false],
         ];
     }
 
@@ -55,5 +59,18 @@ class NumberTest extends AbstractTestCase
         }
 
         $type->validate($value, $fail);
+    }
+
+    public function test_multipleOf_reset(): void
+    {
+        $number = Number::make()
+            ->multipleOf(2)
+            ->multipleOf(null);
+
+        $fail = $this->createMock(MockedCaller::class)
+            ->expects($this->never())
+            ->method('__invoke');
+
+        $number->validate(5, $fail);
     }
 }

--- a/tests/unit/NumberTest.php
+++ b/tests/unit/NumberTest.php
@@ -68,8 +68,7 @@ class NumberTest extends AbstractTestCase
             ->multipleOf(null);
 
         $fail = $this->createMock(MockedCaller::class);
-        $fail->expects($this->never())
-            ->method('__invoke');
+        $fail->expects($this->never())->method('__invoke');
 
         $number->validate(5, $fail);
     }

--- a/tests/unit/NumberTest.php
+++ b/tests/unit/NumberTest.php
@@ -67,8 +67,8 @@ class NumberTest extends AbstractTestCase
             ->multipleOf(2)
             ->multipleOf(null);
 
-        $fail = $this->createMock(MockedCaller::class)
-            ->expects($this->never())
+        $fail = $this->createMock(MockedCaller::class);
+        $fail->expects($this->never())
             ->method('__invoke');
 
         $number->validate(5, $fail);


### PR DESCRIPTION
Follow-up to #113 

I figured out how to fix the `multipleOf` validation without using the modulo operator which doesn't work when using a `multipleOf` value that is a `float` with decimals, caused by the modulo operator converting the `multipleOf` value to integer.

The new validation divides the value of the field by the `multipleOf` value (if not null). If the value is indeed a multiple of the `multipleOf` property, the result should always be a whole number. We can check this by comparing it to the same result but rounded.