### PR TITLE
Bump psr/http-message to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "asispts/http-accept": "^1.0",
         "doctrine/inflector": "^2.0",
         "nyholm/psr7": "^1.8",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^2.0",
         "psr/http-server-handler": "^1.0"
     },
     "license": "MIT",


### PR DESCRIPTION
There is an error with Laravel 12.

```sh
> composer require tobyz/json-api-server

./composer.json has been updated
Running composer update tobyz/json-api-server
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires tobyz/json-api-server * -> satisfiable by tobyz/json-api-server[v0.2.0, v0.2.1].
    - tobyz/json-api-server[v0.2.0, ..., v0.2.1] require psr/http-message ^1.0 -> found psr/http-message[1.0, 1.0.1, 1.1] but the package is fixed to 2.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
You can also try re-running composer require with an explicit version constraint, e.g. "composer require tobyz/json-api-server:*" to figure out if any version is installable, or "composer require tobyz/json-api-server:^2.1" if you know which you need.
```