### PR TITLE
Added an optional included block in the responses

### DIFF
--- a/src/Endpoint/Concerns/BuildsOpenApiPaths.php
+++ b/src/Endpoint/Concerns/BuildsOpenApiPaths.php
@@ -6,7 +6,7 @@ use Tobyz\JsonApiServer\JsonApi;
 
 trait BuildsOpenApiPaths
 {
-    private function buildOpenApiContent(array $resources, bool $multiple = false): array
+    private function buildOpenApiContent(array $resources, bool $multiple = false, bool $included = true): array
     {
         $item = count($resources) === 1 ? $resources[0] : ['oneOf' => $resources];
 
@@ -17,6 +17,7 @@ trait BuildsOpenApiPaths
                     'required' => ['data'],
                     'properties' => [
                         'data' => $multiple ? ['type' => 'array', 'items' => $item] : $item,
+                        'included' => $included ? ['type' => 'array'] : [],
                     ],
                 ],
             ],


### PR DESCRIPTION
# Summary
Adds optional support for the included block in OpenAPI response schemas generated by buildOpenApiContent.

# Motivation
Our frontend team needs the included block explicitly documented in the OpenAPI schema to enable improved type generation and stricter validation when consuming JSON:API responses.

# Changes
- Signature of buildOpenApiContent() updated to include a third parameter:

```php
bool $included = true
```

- When `$included` is true, the method adds an `'included' => ['type' => 'array']` property to the response schema.
- Defaults to true, maintaining expected behaviour with minimal disruption.

# Impact
- Non-breaking: No effect on existing integrations unless the method is called with $included = false.
- Improves DX for frontend consumers by aligning schema output more closely with actual response structure.

