### PR TITLE
Add include parameter

### DIFF
--- a/src/Endpoint/Concerns/BuildsOpenApiPaths.php
+++ b/src/Endpoint/Concerns/BuildsOpenApiPaths.php
@@ -3,6 +3,9 @@
 namespace Tobyz\JsonApiServer\Endpoint\Concerns;
 
 use Tobyz\JsonApiServer\JsonApi;
+use Tobyz\JsonApiServer\Resource\Resource;
+use Tobyz\JsonApiServer\Schema\Field\Field;
+use Tobyz\JsonApiServer\Schema\Field\Relationship;
 
 trait BuildsOpenApiPaths
 {
@@ -18,6 +21,34 @@ trait BuildsOpenApiPaths
                     'properties' => [
                         'data' => $multiple ? ['type' => 'array', 'items' => $item] : $item,
                     ],
+                ],
+            ],
+        ];
+    }
+
+    private function buildOpenApiParameters(Resource $resource): array
+    {
+        $relationshipNames = array_map(
+            fn(Relationship $relationship) => $relationship->name,
+            array_filter(
+                $resource->fields(),
+                fn(Field $field) => $field instanceof Relationship && $field->includable,
+            ),
+        );
+
+        if (empty($relationshipNames)) {
+            return [];
+        }
+
+        $includes = implode(', ', $relationshipNames);
+
+        return [
+            [
+                'name' => 'include',
+                'in' => 'path',
+                'description' => "Available include parameters: {$includes}.",
+                'schema' => [
+                    'type' => 'string',
                 ],
             ],
         ];

--- a/src/Endpoint/Concerns/BuildsOpenApiPaths.php
+++ b/src/Endpoint/Concerns/BuildsOpenApiPaths.php
@@ -45,7 +45,7 @@ trait BuildsOpenApiPaths
         return [
             [
                 'name' => 'include',
-                'in' => 'path',
+                'in' => 'query',
                 'description' => "Available include parameters: {$includes}.",
                 'schema' => [
                     'type' => 'string',

--- a/src/Endpoint/Concerns/BuildsOpenApiPaths.php
+++ b/src/Endpoint/Concerns/BuildsOpenApiPaths.php
@@ -28,6 +28,14 @@ trait BuildsOpenApiPaths
 
     private function buildOpenApiParameters(Resource $resource): array
     {
+        return [
+            ...$this->buildIncludeParameter($resource),
+            ...$this->buildPaginationParameters($resource),
+        ];
+    }
+
+    private function buildIncludeParameter(Resource $resource): array
+    {
         $relationshipNames = array_map(
             fn(Relationship $relationship) => $relationship->name,
             array_filter(
@@ -49,6 +57,28 @@ trait BuildsOpenApiPaths
                 'description' => "Available include parameters: {$includes}.",
                 'schema' => [
                     'type' => 'string',
+                ],
+            ],
+        ];
+    }
+
+    private function buildPaginationParameters(Resource $resource): array
+    {
+        return [
+            [
+                'name' => 'page[limit]',
+                'in' => 'query',
+                'description' => "The limit pagination field.",
+                'schema' => [
+                    'type' => 'number',
+                ],
+            ],
+            [
+                'name' => 'page[offset]',
+                'in' => 'query',
+                'description' => "The offset pagination field.",
+                'schema' => [
+                    'type' => 'number',
                 ],
             ],
         ];

--- a/src/Endpoint/Create.php
+++ b/src/Endpoint/Create.php
@@ -111,6 +111,7 @@ class Create implements Endpoint, OpenApiPathsProvider
                 'post' => [
                     'description' => $this->getDescription(),
                     'tags' => [$collection->name()],
+                    'parameters' => $this->buildOpenApiParameters($collection),
                     'requestBody' => [
                         'required' => true,
                         'content' => $this->buildOpenApiContent(

--- a/src/Endpoint/Index.php
+++ b/src/Endpoint/Index.php
@@ -180,6 +180,7 @@ class Index implements Endpoint, OpenApiPathsProvider
                 'get' => [
                     'description' => $this->getDescription(),
                     'tags' => [$collection->name()],
+                    'parameters' => $this->buildOpenApiParameters($collection),
                     'responses' => [
                         '200' => [
                             'content' => $this->buildOpenApiContent(

--- a/src/Endpoint/Show.php
+++ b/src/Endpoint/Show.php
@@ -52,19 +52,22 @@ class Show implements Endpoint, OpenApiPathsProvider
 
     public function getOpenApiPaths(Collection $collection): array
     {
+        $parameters = [
+            [
+                'name' => 'id',
+                'in' => 'path',
+                'required' => true,
+                'schema' => ['type' => 'string'],
+            ],
+            ...$this->buildOpenApiParameters($collection),
+        ];
+
         return [
             "/{$collection->name()}/{id}" => [
                 'get' => [
                     'description' => $this->getDescription(),
                     'tags' => [$collection->name()],
-                    'parameters' => [
-                        [
-                            'name' => 'id',
-                            'in' => 'path',
-                            'required' => true,
-                            'schema' => ['type' => 'string'],
-                        ],
-                    ],
+                    'parameters' => $parameters,
                     'responses' => [
                         '200' => [
                             'content' => $this->buildOpenApiContent(


### PR DESCRIPTION
# Summary

This PR adds OpenAPI documentation support for the `include` and `page` query parameters across resource endpoints.

# Motivation

To improve API discoverability and enable typed API client generation, we now document which related resources can be included via the `include` parameter. This helps frontend consumers take advantage of JSON:API’s relationship inclusion without relying on external docs or guesswork. We can now include the `page` parameters too.

# Changes

- Introduced `buildOpenApiParameters(Resource $resource)` in the `BuildsOpenApiPaths` trait.
  - Inspects all `Relationship` fields where `$field->includable` is true.
  - Builds a documented `include` parameter with a comma-separated list of supported relationships.
- Applied this to the `Create`, `Index`, and `Show` endpoints by injecting the `parameters` block in their OpenAPI paths.
- For `Show`, the `id` parameter and `include` parameter are now merged into one `parameters` array.

# Impact

- **Non-breaking**: This affects documentation only.
- Documents all includable relationships per resource automatically.
- Helps frontend tooling and developer experience through better OpenAPI typing and clarity.
